### PR TITLE
Fixed charmap codec error

### DIFF
--- a/main.py
+++ b/main.py
@@ -141,7 +141,7 @@ async def load_urls(url):
 # Загрузка списка платформ из локального файла
 async def load_urls_from_file():
     try:
-        with open('platformdb', 'r') as file:
+        with open('platformdb', 'r', encoding='utf-8') as file:
             urls = {}
             for line in file:
                 if line.strip():


### PR DESCRIPTION
On Windows there is an error during plaformdb open:

```
'charmap' codec can't decode byte 0x81 in position 1514: character maps to <undefined>
```

It can be fixed by setting encodig param to 'utf-8' in the open instruction.