### PR TITLE
More domains are required for Copilot. 

### DIFF
--- a/platforms/dns-github-pilot.txt
+++ b/platforms/dns-github-pilot.txt
@@ -1,3 +1,7 @@
 copilot-telemetry.githubusercontent.com
 copilot-proxy.githubusercontent.com
 githubcopilot.com
+github.com
+api.github.com
+default.exp-tas.com
+origin-tracker.githubusercontent.com


### PR DESCRIPTION
Taken from [here](https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/configuring-your-proxy-server-or-firewall-for-copilot)