### PR TITLE
Add `pscp.tv` to Twitter

### DIFF
--- a/platforms/dns-twitter.txt
+++ b/platforms/dns-twitter.txt
@@ -51,3 +51,4 @@ ton.twitter.com
 x.com
 abs.twimg.com
 abs-0.twimg.com
+pscp.tv


### PR DESCRIPTION
`pscp.tv` (old Periscope) runs Spaces on Twitter.