### PR TITLE
Исправление для опечатки api.telegram.orgapi.telegram.org - issue #126 

### DIFF
--- a/platforms/dns-telegram.txt
+++ b/platforms/dns-telegram.txt
@@ -349,7 +349,7 @@ api-dev.telegram.org
 api-test.telegram.org
 api.int.telegram.org
 api.t.me
-api.telegram.orgapi.telegram.org
+api.telegram.org
 api.test.telegram.org
 api.wuhanvirus.kr.t.me
 api2.telegram.org


### PR DESCRIPTION
Заменяет опечатку api.telegram.orgapi.telegram.org на api.telegram.org #126 